### PR TITLE
Update Package.swift

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,9 +5,9 @@
         "package": "Coquille",
         "repositoryURL": "https://github.com/alexrozanski/Coquille.git",
         "state": {
-          "branch": "v0.3",
-          "revision": "4250068ef7d259e0023c099be58459e5d7dbcedd",
-          "version": null
+          "branch": null,
+          "revision": "cb28716215a56760c66a4f635a1f71d6a2e2a42a",
+          "version": "0.3.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     .library(name: "llama", targets: ["llama"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/alexrozanski/Coquille.git", branch: "v0.3")
+    .package(url: "https://github.com/alexrozanski/Coquille.git", from: "0.3.0")
   ],
   targets: [
     .target(


### PR DESCRIPTION
I've updated the [Coquille](https://github.com/alexrozanski/Coquille) dependency to use a tagged version instead of a branch, the previous commit in `Package.resolved` doesn't exist anymore.

This was breaking builds of LlamaChat :) 